### PR TITLE
Remove `height` from `.parallax-fast` to fix double scrolling issue.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -254,7 +254,7 @@ h1, h2, p {
     position: absolute;
     transform: translateZ(5px) scale(0.375);
     margin-top: 15vh;
-    height: 300%;
+    /* height: 300%; */
     width: 100%;
 }
 


### PR DESCRIPTION
Hi!

I just visited your website; I noticed an issue with scrolling within the Hero. Although the parallax effect was present, I mistakenly assumed I had reached the end of the page. To rectify this, I removed the `height` attribute from the `.parallax-fast` container, allowing for a more fluid scrolling experience.

https://user-images.githubusercontent.com/6382364/219897016-2e7ebb28-3f67-45c1-913d-ee0cbf903399.mp4

